### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
           account_key: ${{ secrets.GCLOUD_KEY_PROD }}
 
       - name: Publish to Registry develop
-        uses: elgohr/Publish-Docker-Github-Action@v4
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{secrets.PROJECT_NAME_PROD}}/minio
           username: ${{ steps.gcloud.outputs.username }}

--- a/.github/workflows/pullRequest.yml
+++ b/.github/workflows/pullRequest.yml
@@ -24,7 +24,7 @@ jobs:
           account_key: ${{ secrets.GCLOUD_KEY_DEV }}
 
       - name: Publish to Registry develop
-        uses: elgohr/Publish-Docker-Github-Action@v4
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{secrets.PROJECT_NAME_DEV}}/minio
           username: ${{ steps.gcloud.outputs.username }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore